### PR TITLE
Add flag/option to skip hostName verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+certchk


### PR DESCRIPTION
Hi @mdevan ,
I stumbled across your blog post in the aftermath of an incident where some of our internal TLS assets expired. 
I'm planning on using it to build a small tool to deploy internally to check all our kubernetes clusters and alert if any have assets expiring soon.

I thought I'd PR back the first functionality I added: a flag to skip host verification.

Thanks for blogging and ultimately saving me some time!